### PR TITLE
Fix the issue that API expect auth did not work in iOS platform.

### DIFF
--- a/www/iOSGamesServices.js
+++ b/www/iOSGamesServices.js
@@ -28,7 +28,7 @@ var actions = {
     'showPlayer': 'auth'
 };
 
-for (var action in actions) {
+Object.keys(actions).forEach(function (action) {
     if (actions.hasOwnProperty(action)) {
         var method = actions[action];
 
@@ -50,6 +50,6 @@ for (var action in actions) {
             }
         }
     }
-}
+});
 
 module.exports = new gameServices();


### PR DESCRIPTION
Currently, All GamesServices-API calls "showPlayer(auth)" internally on iOS platform.
I think that this is because for..in() passing reference of 'action'.
This patch takes measures by making substance of keys of actions by Object.keys().